### PR TITLE
게시판 페이징 구현

### DIFF
--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
@@ -1,17 +1,20 @@
 package com.fastcampus.projectboard.controller;
 
 import com.fastcampus.projectboard.domain.type.SearchType;
-import com.fastcampus.projectboard.dto.ArticleDto;
 import com.fastcampus.projectboard.dto.response.ArticleResponse;
 import com.fastcampus.projectboard.dto.response.ArticleWithCommentsResponse;
 import com.fastcampus.projectboard.service.ArticleService;
+import com.fastcampus.projectboard.service.PaginationService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /**
  * /articles
@@ -25,6 +28,7 @@ import org.springframework.web.bind.annotation.*;
 public class ArticleController {
     
     private final ArticleService articleService;
+    private final PaginationService paginationService;
     
     @GetMapping
     public String articles(
@@ -32,7 +36,13 @@ public class ArticleController {
             @RequestParam(required = false) String searchValue,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             ModelMap map){
-        map.addAttribute("articles", articleService.searchArticles(searchType, searchValue, pageable).map(ArticleResponse::from));
+        
+        Page<ArticleResponse> articles = articleService.searchArticles(searchType, searchValue, pageable).map(
+                ArticleResponse::from);
+        
+        List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), articles.getTotalPages());
+        map.addAttribute("articles", articles);
+        map.addAttribute("paginationBarNumbers", barNumbers);
         return "articles/index";
     }
 

--- a/fastcampus-project-board/src/main/resources/templates/articles/index.html
+++ b/fastcampus-project-board/src/main/resources/templates/articles/index.html
@@ -77,23 +77,21 @@
             <td>두번째글</td>
             <td>#spring</td>
             <td>Uno</td>
-            <td>2022-01-02</td>
+            <td><time>2022-01-02</time></td>
         </tr>
         <tr>
             <td>세번째글</td>
             <td>#java</td>
             <td>Uno</td>
-            <td>2022-01-03</td>
+            <td><time>2022-01-03</time></td>
         </tr>
         </tbody>
     </table>
 
-    <nav aria-label="Page navigation example">
+    <nav id="pagination" aria-label="Page navigation example">
         <ul class="pagination justify-content-center">
             <li class="page-item"><a class="page-link" href="#">Previous</a></li>
             <li class="page-item"><a class="page-link" href="#">1</a></li>
-            <li class="page-item"><a class="page-link" href="#">2</a></li>
-            <li class="page-item"><a class="page-link" href="#">3</a></li>
             <li class="page-item"><a class="page-link" href="#">Next</a></li>
         </ul>
     </nav>

--- a/fastcampus-project-board/src/main/resources/templates/articles/index.th.xml
+++ b/fastcampus-project-board/src/main/resources/templates/articles/index.th.xml
@@ -13,4 +13,24 @@
             </attr>
         </attr>
     </attr>
+
+    <attr sel="#pagination">
+        <attr sel="li[0]/a"
+              th:text="'previous'"
+              th:href="@{/articles(page=${articles.number - 1})}"
+              th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
+        />
+        <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
+            <attr sel="a"
+                  th:text="${pageNumber + 1}"
+                  th:href="@{/articles(page=${pageNumber})}"
+                  th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
+            />
+        </attr>
+        <attr sel="li[2]/a"
+              th:text="'next'"
+              th:href="@{/articles(page=${articles.number + 1})}"
+              th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"
+        />
+    </attr>
 </thlogic>

--- a/fastcampus-project-board/src/test/java/com/fastcampus/projectboard/controller/ArticleControllerTest.java
+++ b/fastcampus-project-board/src/test/java/com/fastcampus/projectboard/controller/ArticleControllerTest.java
@@ -4,20 +4,23 @@ import com.fastcampus.projectboard.config.SecurityConfig;
 import com.fastcampus.projectboard.dto.ArticleWithCommentsDto;
 import com.fastcampus.projectboard.dto.UserAccountDto;
 import com.fastcampus.projectboard.service.ArticleService;
+import com.fastcampus.projectboard.service.PaginationService;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -35,28 +38,65 @@ class ArticleControllerTest {
     private final MockMvc mvc;
     
     @MockBean private ArticleService articleService;
+    @MockBean private PaginationService paginationService;
 
     public ArticleControllerTest(@Autowired MockMvc mvc) {
         this.mvc = mvc;
     }
 
     
-//    @Disabled("구현 중")
     @DisplayName("[view][GET] 게시글 리스트 (게시판) 페이지 - 정상 호출")
     @Test
     public void givenNothing_whenRequestingArticlesView_thenReturnsArticleView() throws Exception {
         //Given
         given(articleService.searchArticles(eq(null), eq(null), any(Pageable.class))).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(anyInt(), anyInt())).willReturn(List.of(0, 1, 2, 3, 4));
+        
+        
         //When & Then
         mvc.perform(get("/articles"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("articles/index"))
-                .andExpect(model().attributeExists("articles"));
+                .andExpect(model().attributeExists("articles"))
+                .andExpect(model().attributeExists("paginationBarNumbers"));
         
         then(articleService).should().searchArticles(eq(null), eq(null), any(Pageable.class));
+        then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
         
     }
+    
+    @DisplayName("[view][GET] 게시글 리스트 (게시판) 페이지 - 페이징, 정렬 기능")
+    @Test
+    void givenPagingAndSortingParams_whenSearchingArticlesPage_thenReturnsArticlesPage() throws Exception{
+        //Given
+        String sortName = "title";
+        String direction = "desc";
+        int pageNumber = 0;
+        int pageSize = 5;
+        Pageable pageable= PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Order.desc(sortName)));
+        List<Integer> barNumbers = List.of(1, 2, 3, 4, 5);
+        given(articleService.searchArticles(null, null, pageable)).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(pageable.getPageNumber(),
+                Page.empty().getTotalPages())).willReturn(barNumbers);
+        
+        //When & Then
+        mvc.perform(
+                        get("/articles")
+                                .queryParam("page", String.valueOf(pageNumber))
+                                .queryParam("size", String.valueOf(pageSize))
+                                .queryParam("sort", sortName + "," + direction)
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("articles/index"))
+                .andExpect(model().attributeExists("articles"))
+                .andExpect(model().attribute("paginationBarNumbers", barNumbers));
+        then(articleService).should().searchArticles(null, null, pageable);
+        then(paginationService).should().getPaginationBarNumbers(pageable.getPageNumber(), Page.empty().getTotalPages());
+        
+    }
+    
 
     @DisplayName("[view][GET] 게시글 상세 페이지 - 정상 호출")
     @Test
@@ -74,6 +114,8 @@ class ArticleControllerTest {
                 .andExpect(model().attributeExists("articleComments"));
         then(articleService).should().getArticle(articleId);
     }
+    
+    
     
     @Disabled("구현 중")
     @DisplayName("[view][GET] 게시글 검색 전용 페이지 - 정상 호출")

--- a/fastcampus-project-board/src/test/java/com/fastcampus/projectboard/service/PaginationServiceTest.java
+++ b/fastcampus-project-board/src/test/java/com/fastcampus/projectboard/service/PaginationServiceTest.java
@@ -26,7 +26,7 @@ class PaginationServiceTest {
     
     @DisplayName("현재 페이지 번호와 총 페이지 수를 주면, 페이징 바 리스트를 만들어준다.")
     @MethodSource
-    @ParameterizedTest
+    @ParameterizedTest(name = "[{index}] {0}, {1} => {2}")
     void givenCurrentPageNumberAndTotalPages_whenCalculating_thenReturnsPaginationBarNumbers(int currentPageNumber, int totalPages, List<Integer> expected) {
         
         //Given


### PR DESCRIPTION
* `<ul>` 리스트에 목업 데이터를 두 줄 지운 이유는
반복을 시켜야 하는데 `previous`, `next` 버튼이 있어서 함부로 리스트 원소를 초기화 할 수 없었기 때문
최소한의 원소를 남겨 놓고 치환하는 방식으로 구현

* 스프링 서비스 빈 형태로 설계
* 현재 페이지와 총 페이지 수를 넣어주면
페이지 바에 사용할 번호 리스트를 반환하게끔 설계