### PR TITLE
헤더에 해시태그 메뉴 추가

### DIFF
--- a/fastcampus-project-board/src/main/resources/templates/header.html
+++ b/fastcampus-project-board/src/main/resources/templates/header.html
@@ -9,7 +9,8 @@
     <div class="container">
         <div class="d-flex flex-wrap align-items-center justify-content-center justify-content-lg-start">
             <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
-                <li><a href="/" class="nav-link px-2 text-secondary">Home</a></li>
+                <li><a id="home" href="#" class="nav-link px-2 text-secondary">home</a></li>
+                <li><a id="hashtag" href="#" class="nav-link px-2 text-secondary">hashtags</a></li>
             </ul>
 
             <div class="text-end">

--- a/fastcampus-project-board/src/main/resources/templates/header.th.xml
+++ b/fastcampus-project-board/src/main/resources/templates/header.th.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#home" th:href="@{/}" />
+    <attr sel="#hashtag" th:href="@{/articles/search-hashtag}" />
+</thlogic>


### PR DESCRIPTION
#36 에서 구현한 해시태그 페이지로 진입할 방법이 없어
헤더로 해시태그 메뉴에 진입하는 탭을 만든다.