### PR TITLE
JpaConfig 추가

### DIFF
--- a/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/config/JpaConfig.java
+++ b/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/config/JpaConfig.java
@@ -1,10 +1,15 @@
 package com.fastcampus.projectboard.config;
 
+import com.fastcampus.projectboard.dto.security.BoardPrincipal;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 
+import java.security.Principal;
 import java.util.Optional;
 
 @Configuration
@@ -13,6 +18,13 @@ public class JpaConfig {
 
     @Bean
     public AuditorAware<String> auditorAware() {
-        return () -> Optional.of("choi"); // TODO: 스프링 시큐리티로 인증 기능을 붙이게 될 때, 수정하자
+        // TODO: 스프링 시큐리티로 인증 기능을 붙이게 될 때, 수정하자
+        return () -> Optional.ofNullable(SecurityContextHolder.getContext())
+                .map(SecurityContext::getAuthentication)
+                .filter(Authentication::isAuthenticated)
+                .map(Authentication::getPrincipal)
+                .map(BoardPrincipal.class::cast)
+                .map(BoardPrincipal::getUsername);
     }
+    
 }

--- a/fastcampus-project-board/src/test/java/com/fastcampus/projectboard/config/TestSecurityConfig.java
+++ b/fastcampus-project-board/src/test/java/com/fastcampus/projectboard/config/TestSecurityConfig.java
@@ -1,0 +1,30 @@
+package com.fastcampus.projectboard.config;
+
+import com.fastcampus.projectboard.domain.UserAccount;
+import com.fastcampus.projectboard.repository.UserAccountRepository;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.event.annotation.BeforeTestMethod;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@Import(SecurityConfig.class)
+public class TestSecurityConfig {
+    
+    @MockBean private UserAccountRepository userAccountRepository;
+    
+    @BeforeTestMethod
+    public void securitySetUp() {
+        given(userAccountRepository.findById(anyString())).willReturn(Optional.of(UserAccount.of(
+                "kunTest",
+                "pw",
+                "kun-test@email.com",
+                "kun",
+                "memo"
+        )));
+    }
+    
+}

--- a/fastcampus-project-board/src/test/java/com/fastcampus/projectboard/controller/ArticleControllerTest.java
+++ b/fastcampus-project-board/src/test/java/com/fastcampus/projectboard/controller/ArticleControllerTest.java
@@ -135,6 +135,7 @@ class ArticleControllerTest {
         Long articleId = 1L;
         long totalCount = 1L;
         given(articleService.getArticleWithComments(articleId)).willReturn(createArticleWithCommentsDto());
+        given(articleService.getArticleCount()).willReturn(totalCount);
         
         // When & Then
         mvc.perform(get("/articles/" + articleId))
@@ -142,7 +143,6 @@ class ArticleControllerTest {
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("articles/detail"))
                 .andExpect(model().attributeExists("article"))
-                .andExpect(model().attributeExists("articleComments"))
                 .andExpect(model().attributeExists("articleComments"))
                 .andExpect(model().attribute("totalCount", totalCount));
         then(articleService).should().getArticleWithComments(articleId);

--- a/fastcampus-project-board/src/test/java/com/fastcampus/projectboard/controller/AuthControllerTest.java
+++ b/fastcampus-project-board/src/test/java/com/fastcampus/projectboard/controller/AuthControllerTest.java
@@ -8,12 +8,14 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("View 컨트롤러 - 인증")
 @Import(SecurityConfig.class)
-@WebMvcTest
+@WebMvcTest(Void.class)
 class AuthControllerTest {
 
     private final MockMvc mvc;
@@ -30,7 +32,9 @@ class AuthControllerTest {
         //When & Then
         mvc.perform(get("/login"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML));
+                .andExpect(content()
+                        .contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andDo(MockMvcResultHandlers.print());
     }
 
 

--- a/fastcampus-project-board/src/test/java/com/fastcampus/projectboard/repository/JpaRepositoryTest.java
+++ b/fastcampus-project-board/src/test/java/com/fastcampus/projectboard/repository/JpaRepositoryTest.java
@@ -7,14 +7,19 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("JPA 연결 테스트")
-@Import(JpaConfig.class)
+@Import(JpaRepositoryTest.TestJpaConfig.class)
 @DataJpaTest
 class JpaRepositoryTest {
 
@@ -91,6 +96,16 @@ class JpaRepositoryTest {
         // Then
         assertThat(articleRepository.count()).isEqualTo(previousArticleCount - 1);
         assertThat(articleCommentRepository.count()).isEqualTo(previousArticleCommentCount - deletedCommentsSize);
+    }
+    
+    @EnableJpaAuditing
+    @TestConfiguration
+    public static class TestJpaConfig{
+        @Bean
+        public AuditorAware<String> auditorAware() {
+            return () -> Optional.of("choi");
+        }
+        
     }
 
 }


### PR DESCRIPTION
Jpa와 관련된 테스트에서 Security를 적용하고
난 후 에러가 발생하는 부분을 @TestConfiguration,
@BeforeTestMethod를 이용해 계정 정보를 넣어줌.